### PR TITLE
chore: build warning fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- BEGIN:nextjs-agent-rules -->
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+
+**Keep this block, including in commits.** It is part of the project's agent setup, maintained by `next dev` for every agent that works here. If it appears as an uncommitted change, that is intentional — commit it as-is. Do not remove it to clean up a diff; it will be regenerated.
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/lib/rehype-component.ts
+++ b/src/lib/rehype-component.ts
@@ -33,7 +33,7 @@ export function rehypeComponent() {
           let src: string;
 
           if (srcPath) {
-            src = path.join(process.cwd(), srcPath);
+            src = path.join(/* turbopackIgnore: true */ process.cwd(), srcPath);
           } else {
             const component = Index[name];
             src = fileName
@@ -51,7 +51,7 @@ export function rehypeComponent() {
 
           // Read the source file.
           const filePath = src;
-          let source = fs.readFileSync(filePath, "utf8");
+          let source = fs.readFileSync(/* turbopackIgnore: true */ filePath, "utf8");
 
           // Replace imports.
           // TODO: Use @swc/core and a visitor to replace this.
@@ -111,7 +111,7 @@ export function rehypeComponent() {
 
           // Read the source file.
           const filePath = src;
-          let source = fs.readFileSync(filePath, "utf8");
+          let source = fs.readFileSync(/* turbopackIgnore: true */ filePath, "utf8");
 
           // Replace imports.
           // TODO: Use @swc/core and a visitor to replace this.

--- a/src/lib/remark-code-import.js
+++ b/src/lib/remark-code-import.js
@@ -34,7 +34,7 @@ function extractLines(
 
 export function remarkCodeImport(options = {}) {
   // Default rootDir is the "src" directory in the current working directory
-  const rootDir = options.rootDir || path.join(process.cwd(), "src");
+  const rootDir = options.rootDir || path.join(/* turbopackIgnore: true */ process.cwd(), "src");
 
   if (!path.isAbsolute(rootDir)) {
     throw new Error(`"rootDir" has to be an absolute path`);
@@ -98,7 +98,7 @@ export function remarkCodeImport(options = {}) {
         );
       }
 
-      const fileContent = fs.readFileSync(fileAbsPath, "utf8");
+      const fileContent = fs.readFileSync(/* turbopackIgnore: true */ fileAbsPath, "utf8");
 
       node.value = extractLines(
         fileContent,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project guidance for AI assistants, including a required Next.js-specific rules section.
  * Updated the assistant instructions file to reference the project guidance.
  * Improved Turbopack compatibility for code import and component source/preview processing, helping builds handle these paths more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->